### PR TITLE
fix: source `tsch` environment file from anywhere

### DIFF
--- a/environ.csh
+++ b/environ.csh
@@ -1,5 +1,15 @@
 #!/bin/tcsh
+set this_cmd=($_)
+set this_dir=`dirname ${this_cmd[2]}`
+setenv QADB `cd ${this_dir} && pwd -P`
 
-setenv QADB `pwd -P`
-setenv JYPATH "${QADB}/src/"
-env|grep --color -w JYPATH
+set src_dir=${QADB}/src/
+if (! $?JYPATH) then
+  setenv JYPATH $src_dir
+else
+  if ("$JYPATH" == "") then
+    setenv JYPATH $src_dir
+  else
+    setenv JYPATH $src_dir\:$JYPATH
+  endif
+endif


### PR DESCRIPTION
Allows `environ.csh` to be `source`d from anywhere.