### PR TITLE
fix: silenece misleading warnings

### DIFF
--- a/src/clasqa/QADB.groovy
+++ b/src/clasqa/QADB.groovy
@@ -288,10 +288,7 @@ class QADB {
   public String getComment() { return found ? comment : "" }
   public int getEvnumMin() { return found ? evnumMin : -1 }
   public int getEvnumMax() { return found ? evnumMax : -1 }
-  public double getCharge() {
-    System.err.println "WARNING: the charge stored in the Pass 1 QADB for Run Groups A, B, K, and M is NOT quite correct, and may be off by ~1%, depending on the particular runs! This will be fixed for their Pass 2 data sets."
-    return found ? charge : -1
-  }
+  public double getCharge() { return found ? charge : -1 }
   // --- access QA info
   // check if the file has a particular defect
   // - if sector==0, checks the OR of all the sectors
@@ -468,7 +465,6 @@ class QADB {
   // -- accessor
   // call this method at the end of your event loop
   public double getAccumulatedCharge() {
-    System.err.println "WARNING: the charge stored in the Pass 1 QADB for Run Groups A, B, K, and M is NOT quite correct, and may be off by ~1%, depending on the particular runs! This will be fixed for their Pass 2 data sets."
     return chargeTotal
   }
   // reset accumulated charge, if you ever need to

--- a/src/tests/testDumpQADB.groovy
+++ b/src/tests/testDumpQADB.groovy
@@ -62,8 +62,11 @@ runlistFile.eachLine { runnumStr ->
 
     // check event number: report an error if evnum min>=max
     println qa.getEvnumMin() + " " + qa.getEvnumMax()
-    if(qa.getEvnumMin() >= qa.getEvnumMax())
-      err("GetEvnumMin() >= GetEvnumMax()");
+    if(qa.getEvnumMin() >= qa.getEvnumMax()) {
+      if(binnum != 0 && binnum != qa.getMaxBinnum(runnum)) { // don't bother, if not first or last bin
+        err("GetEvnumMin() >= GetEvnumMax()")
+      }
+    }
 
     // print charge (convert to pC and truncate, for easier comparison)
     // println "- charge"

--- a/srcC/include/QADB.h
+++ b/srcC/include/QADB.h
@@ -126,10 +126,7 @@ namespace QA {
       inline std::string GetComment() { return found ? comment : ""; };
       inline int GetEvnumMin() { return found ? evnumMin : -1; };
       inline int GetEvnumMax() { return found ? evnumMax : -1; };
-      inline double GetCharge() {
-        std::cerr << "WARNING: the charge stored in the Pass 1 QADB for Run Groups A, B, K, and M is NOT quite correct, and may be off by ~1%, depending on the particular runs! This will be fixed for their Pass 2 data sets." << std::endl;
-        return found ? charge : -1;
-      }
+      inline double GetCharge() { return found ? charge : -1; };
       // --- access QA info
       // check if the file has a particular defect
       // - if sector==0, checks the OR of all the sectors
@@ -194,7 +191,6 @@ namespace QA {
       // returns total accumlated charge that passed your QA cuts; call this
       // method after your event loop
       inline double GetAccumulatedCharge() {
-        std::cerr << "WARNING: the charge stored in the Pass 1 QADB for Run Groups A, B, K, and M is NOT quite correct, and may be off by ~1%, depending on the particular runs! This will be fixed for their Pass 2 data sets." << std::endl;
         return chargeTotal;
       }
       // reset accumulated charge, if you ever need to

--- a/srcC/tests/testDumpQADB.cpp
+++ b/srcC/tests/testDumpQADB.cpp
@@ -68,8 +68,11 @@ int main(int argc, char ** argv) {
 
       // check event number: report an error if evnum min>=max
       cout << qa->GetEvnumMin() << " " << qa->GetEvnumMax() << endl;
-      if(qa->GetEvnumMin() >= qa->GetEvnumMax())
-        err("GetEvnumMin() >= GetEvnumMax()");
+      if(qa->GetEvnumMin() >= qa->GetEvnumMax()) {
+        if(binnum != 0 && binnum != qa->GetMaxBinnum(runnum)) { // don't bother, if not first or last bin
+          err("GetEvnumMin() >= GetEvnumMax()");
+        }
+      }
 
       // print charge (convert to pC and truncate, for easier comparison)
       // chargeInt = (int) (1000*qa->GetCharge()); // FIXME: too many warnings


### PR DESCRIPTION
- pass 1 charge, since we have https://github.com/JeffersonLab/clas12-qadb/issues/48 and refer users to check such pinned issues in the documentation
  - this warning was printed regardless of whether the dataset has the issue (QA per DST file) or not (QA per time bin)
- sometimes the first or last time bin has zero events, and therefore the min and max event numbers are equal