### PR TITLE
feat: helicity correction function `QADB::CorrectHelicitySign`

### DIFF
--- a/src/clasqa/QADB.groovy
+++ b/src/clasqa/QADB.groovy
@@ -7,8 +7,9 @@ import clasqa.Tools
 
 class QADB {
 
-  final MISC_BIT     = 5 // FIXME: should be obtained from `defect_definitions.json`
-  final BSAWRONG_BIT = 10
+  final MISC_BIT       = 5 // FIXME: should be obtained from `defect_definitions.json`
+  final BSAWRONG_BIT   = 10
+  final BSAUNKNOWN_BIT = 11
 
   //..............
   // constructor
@@ -482,7 +483,8 @@ class QADB {
   //   which indicates the helicity sign in the data is incorrect
   // - therefore:
   //   'true helicity' = 'helicity from data' * CorrectHelicitySign(run_number, event_number)
-  // - zero is returned, if the event is not found in the QADB
+  // - zero is returned, if the event is not found in the QADB or if the pion BSA
+  //   sign is not distinguishable from zero
   // - the return value is constant for a run, but is still assigned per QA bin, for
   //   full generality
   // - the return value may NOT be constant for all runs in a data set; for example,
@@ -491,6 +493,9 @@ class QADB {
   public int correctHelicitySign(int runnum_, int evnum_) {
     def foundHere = query(runnum_,evnum_)
     if(!foundHere) {
+      return 0
+    }
+    if(hasDefectBit(BSAUNKNOWN_BIT)) {
       return 0
     }
     return hasDefectBit(BSAWRONG_BIT) ? -1 : 1

--- a/src/clasqa/QADB.groovy
+++ b/src/clasqa/QADB.groovy
@@ -7,6 +7,9 @@ import clasqa.Tools
 
 class QADB {
 
+  final MISC_BIT     = 5 // FIXME: should be obtained from `defect_definitions.json`
+  final BSAWRONG_BIT = 10
+
   //..............
   // constructor
   //``````````````
@@ -264,9 +267,9 @@ class QADB {
       return false
     }
     def use_mask = mask
-    if(hasDefectBit(5)) {
+    if(hasDefectBit(MISC_BIT)) {
       if(runnum_ in allowMiscBitList) {
-        use_mask &= ~(0x1 << 5) // set `use_mask`'s Misc bit to 0
+        use_mask &= ~(0x1 << MISC_BIT) // set `use_mask`'s Misc bit to 0
       }
     }
     return foundHere && !(defect & use_mask)
@@ -470,6 +473,28 @@ class QADB {
   // reset accumulated charge, if you ever need to
   public void resetAccumulatedCharge() { chargeTotal = 0 }
 
+
+  //.................................
+  // Helicity Sign Correction
+  //`````````````````````````````````
+  // use this method to get the correct helicity sign:
+  // - this method returns -1 if the QA bin has the `BSAWrong` defect,
+  //   which indicates the helicity sign in the data is incorrect
+  // - therefore:
+  //   'true helicity' = 'helicity from data' * CorrectHelicitySign(run_number, event_number)
+  // - zero is returned, if the event is not found in the QADB
+  // - the return value is constant for a run, but is still assigned per QA bin, for
+  //   full generality
+  // - the return value may NOT be constant for all runs in a data set; for example,
+  //   deviations from the normal value happen when a single run is cooked with the
+  //   wrong HWP position
+  public int correctHelicitySign(int runnum_, int evnum_) {
+    def foundHere = query(runnum_,evnum_)
+    if(!foundHere) {
+      return 0
+    }
+    return hasDefectBit(BSAWRONG_BIT) ? -1 : 1
+  }
 
 
   //===============================================================

--- a/src/tests/testCorrectHelicitySign.groovy
+++ b/src/tests/testCorrectHelicitySign.groovy
@@ -1,0 +1,14 @@
+import clasqa.QADB
+
+def runnum
+final EVNUM = 100000 // FIXME: assumption
+def cook
+if(args.length>=2) {
+  cook   = args[0]
+  runnum = args[1].toInteger()
+} else {
+  throw new Exception("arguments must be [cook] [runnum]")
+}
+
+QADB qa = new QADB(cook)
+System.out.println(qa.correctHelicitySign(runnum, EVNUM))

--- a/src/tests/testDumpQADB.groovy
+++ b/src/tests/testDumpQADB.groovy
@@ -76,6 +76,8 @@ runlistFile.eachLine { runnumStr ->
     // print comment
     println "comment: \"" + qa.getComment() + "\""
 
+    // print helicity sign correction
+    println "helicity sign: ${qa.correctHelicitySign(runnum, evnum)}"
 
     // print overall defect info
     println "- defect"

--- a/srcC/include/QADB.h
+++ b/srcC/include/QADB.h
@@ -14,8 +14,9 @@
 
 namespace QA {
 
-  int const MISC_BIT     = 5;  // FIXME: should be obtained from `defect_definitions.json`
-  int const BSAWRONG_BIT = 10;
+  int const MISC_BIT       = 5;  // FIXME: should be obtained from `defect_definitions.json`
+  int const BSAWRONG_BIT   = 10;
+  int const BSAUNKNOWN_BIT = 11;
 
   class QADB {
     private:
@@ -210,7 +211,8 @@ namespace QA {
       //   which indicates the helicity sign in the data is incorrect
       // - therefore:
       //   'true helicity' = 'helicity from data' * CorrectHelicitySign(run_number, event_number)
-      // - zero is returned, if the event is not found in the QADB
+      // - zero is returned, if the event is not found in the QADB or if the pion BSA
+      //   sign is not distinguishable from zero
       // - the return value is constant for a run, but is still assigned per QA bin, for
       //   full generality
       // - the return value may NOT be constant for all runs in a data set; for example,
@@ -689,6 +691,8 @@ namespace QA {
   int QADB::CorrectHelicitySign(int runnum_, int evnum_) {
     bool foundHere = this->Query(runnum_,evnum_);
     if(!foundHere)
+      return 0;
+    if(this->HasDefectBit(BSAUNKNOWN_BIT))
       return 0;
     return this->HasDefectBit(BSAWRONG_BIT) ? -1 : 1;
   }

--- a/srcC/tests/Makefile
+++ b/srcC/tests/Makefile
@@ -1,4 +1,4 @@
-CXX = g++ -std=c++11
+CXX = g++ -std=c++17
 FLAGS = -g -Wno-deprecated -fPIC -m64 -fno-inline -Wno-write-strings
 
 ifndef QADB

--- a/srcC/tests/testCorrectHelicitySign.cpp
+++ b/srcC/tests/testCorrectHelicitySign.cpp
@@ -1,0 +1,21 @@
+#include <iostream>
+#include <bitset>
+#include <memory>
+
+#include "QADB.h"
+
+int main(int argc, char ** argv) {
+
+  int runnum;
+  int const EVNUM = 100000; // FIXME: assumption
+  std::string cook;
+  if(argc>2) {
+    cook   = std::string(argv[1]);
+    runnum = std::stoi(argv[2]);
+  }
+  else throw std::runtime_error("arguments must be [cook] [runnum]");
+
+  auto qa = std::make_unique<QA::QADB>(cook);
+  std::cout << qa->CorrectHelicitySign(runnum, EVNUM) << std::endl;
+  return 0;
+}

--- a/srcC/tests/testDumpQADB.cpp
+++ b/srcC/tests/testDumpQADB.cpp
@@ -83,6 +83,8 @@ int main(int argc, char ** argv) {
       // print comment
       cout << "comment: \"" << qa->GetComment() << "\"" << endl;
 
+      // print helicity sign correction
+      cout << "helicity sign: " << qa->CorrectHelicitySign(runnum, evnum) << endl;
 
       // print overall defect info
       cout << "- defect" << endl;

--- a/util/Makefile
+++ b/util/Makefile
@@ -1,4 +1,4 @@
-CXX = g++ -std=c++11
+CXX = g++ -std=c++17
 FLAGS = -g -Wno-deprecated -fPIC -m64 -fno-inline -Wno-write-strings
 
 # QADB and rapidjson


### PR DESCRIPTION
This function allows users to correct the helicity sign from the data, based on QA analysis of the semi-inclusive $ep \to e\pi^+X$ beam spin asymmetry sign. Basically:
```
'true helicity' = 'helicity from cooked data' * CorrectHelicitySign(run_number, event_number)
```
This `CorrectHelicitySign` function returns:
- $+1$ if the helicity sign is correct (pion beam spin asymmetry sign is correct)
- $-1$ if the helicity sign is _not_ correct (pion beam spin asymmetry sign is _not_ correct, _i.e._, the QA bin has the `BSAWrong` defect bit)
- $0$ if unknown (_i.e._, the QA bin has the `BSAUnknown` defect bit)