### PR TITLE
Added the accumulator functions for the FC Helicity-Lathced charge in…

### DIFF
--- a/src/clasqa/QADB.groovy
+++ b/src/clasqa/QADB.groovy
@@ -574,7 +574,7 @@ class QADB {
   private double charge,chargeMin,chargeMax,chargeTotal
   private boolean chargeCounted
   private def chargeCountedFiles
-  private double chargeHL // Helicity Latched charge
+  private def chargeHL // Helicity Latched charge
   private double chargeHLTotalMinus // Helicity Latched charge accumulated sum for -1 state
   private double chargeHLTotalZero  // Helicity Latched charge accumulated sum for 0 state
   private double chargeHLTotalPlus  // Helicity Latched charge accumulated sum for +1 state

--- a/src/clasqa/QADB.groovy
+++ b/src/clasqa/QADB.groovy
@@ -416,9 +416,6 @@ class QADB {
           if(chargeTree["$runnum"]["$filenum"].containsKey("fcChargeHelicity")){
             chargeHL = chargeTree["$runnum"]["$filenum"]["fcChargeHelicity"]
             chargeHLCounted = false
-          }else{
-            System.err << "WARNING: QADB::queryByFilenum, No fcChargeHelicity for " <<
-            "runnum=$runnum_ filenum=$filenum_\n"
           }
           
           found = true
@@ -521,7 +518,7 @@ class QADB {
     }else if(state==1){
       ret = chargeHLTotalPlus
     }else{
-      System.err << "Invalid helicity state $state.  Use -1, 0, or 1 \n"  
+      throw new Exception("Invalid helicity state $state.  Use -1, 0, or 1")
     }
     return ret
   }
@@ -577,10 +574,10 @@ class QADB {
   private double charge,chargeMin,chargeMax,chargeTotal
   private boolean chargeCounted
   private def chargeCountedFiles
-  private chargeHL // Helicity Latched charge
-  private chargeHLTotalMinus // Helicity Latched charge accumulated sum for -1 state
-  private chargeHLTotalZero  // Helicity Latched charge accumulated sum for 0 state
-  private chargeHLTotalPlus  // Helicity Latched charge accumulated sum for +1 state
+  private double chargeHL // Helicity Latched charge
+  private double chargeHLTotalMinus // Helicity Latched charge accumulated sum for -1 state
+  private double chargeHLTotalZero  // Helicity Latched charge accumulated sum for 0 state
+  private double chargeHLTotalPlus  // Helicity Latched charge accumulated sum for +1 state
   private boolean chargeHLCounted
   private def chargeHLCountedFiles
   private int defect

--- a/src/clasqa/QADB.groovy
+++ b/src/clasqa/QADB.groovy
@@ -518,7 +518,7 @@ class QADB {
     }else if(state==1){
       ret = chargeHLTotalPlus
     }else{
-      throw new Exception("Invalid helicity state $state.  Use -1, 0, or 1")
+      throw new RuntimeException("Invalid helicity state $state.  Use -1, 0, or 1")
     }
     return ret
   }

--- a/src/tests/testHelicityLatchedCharge.groovy
+++ b/src/tests/testHelicityLatchedCharge.groovy
@@ -20,11 +20,8 @@ def HLstate = [-1,0,1]
 def runnumList = [
   5695,
   16042,
-  16043,
-  16044,
-  16047,
-  16048,
-  16049
+  16049,
+  16138
 ]
 
 // specify QA criteria

--- a/src/tests/testHelicityLatchedCharge.groovy
+++ b/src/tests/testHelicityLatchedCharge.groovy
@@ -4,24 +4,28 @@
 // imports
 import clasqa.QADB // access QADB
 
+
 // instantiate QADB
 QADB qa = new QADB("latest")
 // alternatively, specify run range to restrict QADB (may be more efficient)
 //QADB qa = new QADB("latest",5000,5500);
+// additionally, you can specify a run range in verbose mode
+//QADB qa = new QADB("latest",-1,-1,true)
 int evnum
 def defname
 int chargeInt
-
+def HLstate = [-1,0,1]
 
 // specify run number list
 def runnumList = [
-  5682,
-  5683,
   5695,
-  5751,
-  5827
+  16042,
+  16043,
+  16044,
+  16047,
+  16048,
+  16049
 ]
-
 
 // specify QA criteria
 qa.checkForDefect("SectorLoss")
@@ -46,13 +50,16 @@ runnumList.each{ runnum ->
       qa.pass(runnum,evnum) &&
       !( runnum==5827 && (filenum==10 || filenum==45 || filenum==50) )
     ) {
-      qa.accumulateCharge()
+      qa.accumulateChargeHL()
     }
 
   } // end file loop
 
   // print this run's charge, and reset
-  println "$runnum " + qa.getAccumulatedCharge()
-  qa.resetAccumulatedCharge()
+  println "$runnum "
+  HLstate.each{ value ->
+    println "HL charge(" + value + ")= " + qa.getAccumulatedChargeHL(value)
+  }
+  qa.resetAccumulatedChargeHL()
 
 } // end run loop


### PR DESCRIPTION
In QADB.groovy, information about the Helicity-Latched charge has been added.  The following accumulator functions have been added:

- accumulateChargeHL() : sum the charges per run number
- getAccumulatedChargeHL(int state) : return the total charge for each helicity state.  Return an error message if an invalid state is input.
- resetAccumulatedChargeHL() - reset the totals to zero.

The Helicity-Latched charges are extracted in the queryByFilenum() function.  They are saved in a List.  An error message is printed if there is no HL charge for a run number and file number.  

Added a test groovy script called src/tests/testHelicityLatchedCharge.groovy.

The error checking for the Helicity-Latched charge will produce a lot of print statements for each run number.  Not sure if this is something that should be in verbose mode or always print out.  The totals will report -1 if the information does not exist.

